### PR TITLE
Fix all books list

### DIFF
--- a/src/main/java/fish/payara/sample/debugging/service/LibraryEndpoints.java
+++ b/src/main/java/fish/payara/sample/debugging/service/LibraryEndpoints.java
@@ -44,7 +44,7 @@ public class LibraryEndpoints implements LibraryService {
     @Override
     public Book addBookToLibrary(String name, Book book) {
         Library library = getLibrary(name);
-        library.getBooks().add(book);
+        model.addBook(library, book);
         return book;
     }
 


### PR DESCRIPTION
When a book is added to a library (POST _/api/libraries/{name}_), it is now added to the global list of books (GET _/api/books_).